### PR TITLE
ci/docs: release notes automation + caching + retention

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,16 @@
+name-template: 'v$NEXT_PATCH_VERSION'
+tag-template: 'v$NEXT_PATCH_VERSION'
+categories:
+  - title: '🚀 Features'
+    labels: ['feature','enhancement']
+  - title: '🐞 Fixes'
+    labels: ['bug','fix']
+  - title: '🧰 Maintenance'
+    labels: ['chore','maintenance','refactor','docs','ci']
+change-template: '- $TITLE (#$NUMBER) — @$AUTHOR'
+template: |
+  ## Changes
+  $CHANGES
+
+  ## Contributors
+  $CONTRIBUTORS

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,18 @@ jobs:
   build_android:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*','**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
       - uses: actions/checkout@v4
         with: { lfs: true }
       - name: Git LFS
@@ -112,6 +124,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Android Debug APK
+          retention-days: 30
           path: |
             build/app/outputs/flutter-apk/app-debug.apk
             build/app/outputs/apk/debug/app-debug.apk
@@ -120,6 +133,18 @@ jobs:
   build_windows:
     runs-on: windows-latest
     steps:
+      - uses: actions/cache@v4
+        with:
+          path: ~/.pub-cache
+          key: ${{ runner.os }}-pub-${{ hashFiles('pubspec.lock') }}
+          restore-keys: ${{ runner.os }}-pub-
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*','**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
       - name: Enable long paths
         run: git config --system core.longpaths true
 
@@ -177,6 +202,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: Windows Release
+          retention-days: 30
           path: build/windows/x64/runner/Release/**
           if-no-files-found: error
   android_qa_smoke:
@@ -237,6 +263,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: android-smoke-logs
+          retention-days: 30
           path: smoke-logs/**
 
   release_assets:
@@ -246,6 +273,23 @@ jobs:
     permissions:
       contents: write
     steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Generate changelog
+        run: |
+          git fetch --tags --force
+          curr="${GITHUB_REF_NAME}"
+          prev="$(git tag --sort=-creatordate | grep -v "^$curr$" | head -n1 || true)"
+          if [ -n "$prev" ]; then range="$prev..$curr"; else range=""; fi
+          mkdir -p dist
+          echo "## Changelog for $curr" > dist/CHANGELOG-$curr.md
+          if [ -n "$range" ]; then
+            echo "" >> dist/CHANGELOG-$curr.md
+            git log --pretty=format:'- %s (%h) — %an' $range >> dist/CHANGELOG-$curr.md
+          else
+            echo "- Initial tagged release notes" >> dist/CHANGELOG-$curr.md
+          fi
       - uses: actions/download-artifact@v4
         with:
           name: Android Debug APK
@@ -282,6 +326,8 @@ jobs:
       - name: Attach to GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          append_body: true
+          body_path: dist/CHANGELOG-${{ github.ref_name }}.md
           files: |
             dist/HoldThatThought-${{ github.ref_name }}-debug.apk
             dist/HoldThatThought-${{ github.ref_name }}-debug.apk.sha256

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,15 @@
+name: Release Drafter
+'on':
+  push:
+    branches: [ main ]
+permissions:
+  contents: write
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        with:
+          config-name: release-drafter.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds Release Drafter, CI caches, artifact retention, and auto-changelog appended to tag releases.

## Changes
- **Release Drafter**: Adds automated release notes workflow that drafts releases on main branch pushes
- **CI Caching**: Adds pub cache and Gradle cache to build jobs for faster builds
- **Artifact Retention**: Sets 30-day retention for all CI artifacts
- **Auto-changelog**: Generates changelog between git tags and appends to GitHub releases
- **Release Body Enhancement**: Auto-appends changelog to release description

## Benefits
- Faster CI builds through effective caching
- Better storage management with artifact retention
- Automated release documentation
- Enhanced release experience with changelogs

This enhances the release automation pipeline with better performance and documentation.