### PR TITLE
ci(android): Play internal upload on stable tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,4 +335,52 @@ jobs:
             dist/HoldThatThought-${{ github.ref_name }}-windows.zip.sha256
           prerelease: ${{ contains(github.ref_name, '-rc') }}
 
+  release_android_play:
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
+    needs: [build_android]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+
+      # Restore keystore from secret (Base64)
+      - name: Restore Android signing key
+        env:
+          ANDROID_SIGNING_KEY_B64: ${{ secrets.ANDROID_SIGNING_KEY_B64 }}
+        run: |
+          mkdir -p android/app
+          echo "$ANDROID_SIGNING_KEY_B64" | base64 -d > android/app/release.keystore
+
+      # Create key.properties for Gradle
+      - name: Write key.properties
+        run: |
+          cat > android/key.properties <<'EOF'
+          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
+          storeFile=release.keystore
+          EOF
+
+      # Build signed AAB (Flutter delegates to Gradle + key.properties)
+      - name: Build AAB (release)
+        run: flutter build appbundle --release
+
+      # Upload to Google Play (internal track)
+      - name: Upload to Google Play (internal)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ secrets.PLAY_PACKAGE_NAME }}
+          releaseFiles: build/app/outputs/bundle/release/app-release.aab
+          track: internal
+          status: completed
 


### PR DESCRIPTION
Build signed AAB and upload to Google Play internal track when pushing v* tags without -rc.