### PR TITLE
ci: fix tag triggers + add probe; correct job guards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,16 @@ permissions:
   pull-requests: write
 
 jobs:
+  tag_probe:
+    name: Tag Probe
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - name: Echo Context
+        run: echo "ref=$GITHUB_REF, ref_name=${{ github.ref_name }}"
+
   build_android:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Normalize on: push tags v*, PRs, dispatch. Add non-blocking tag probe. Ensure build jobs run on tags; keep release_assets on tags; Play job on stable tags only.