### PR TITLE
ci: self-heal builds (setup-android, doctor, logs)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,22 @@ jobs:
         run: echo "ref=$GITHUB_REF, ref_name=${{ github.ref_name }}"
 
   build_android:
-    env:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3g
+  env:
+    GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3g -Dkotlin.daemon.jvm.options=-Xmx2g
+    ORG_GRADLE_PROJECT_android.injected.testOnly: 'true'
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: android-actions/setup-android@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+      - name: Android Doctor (preflight)
+        run: bash tools/ci/doctor_android.sh
       - uses: actions/cache@v4
         with:
           path: ~/.pub-cache
@@ -140,6 +152,17 @@ jobs:
       - name: List build outputs
         run: |
           find build -name "*.apk" || true
+      - name: Upload doctor logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: android-doctor-logs
+          path: |
+            build-dryrun.log
+            build-deps.log
+            **/reports/**
+          retention-days: 14
+
       - name: Upload Android Debug APK
         uses: actions/upload-artifact@v4
         with:
@@ -152,7 +175,8 @@ jobs:
 
   build_windows:
     env:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3g
+      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3g -Dkotlin.daemon.jvm.options=-Xmx2g
+      ORG_GRADLE_PROJECT_android.injected.testOnly: 'true'
       FLUTTER_WINDOWS: 'true'
     runs-on: windows-latest
     steps:

--- a/tools/ci/doctor_android.sh
+++ b/tools/ci/doctor_android.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echo "== Android Doctor =="
+echo "Java:"; java -version || true
+echo "Gradle wrapper:"; (cd android && ./gradlew -v || true)
+echo "Flutter:"; flutter --version || true
+echo "SDK root: ${ANDROID_SDK_ROOT:-unset}"
+
+# Accept licenses and list current packages
+yes | sdkmanager --licenses >/dev/null || true
+sdkmanager --list | head -n 40 || true
+
+# Detect compileSdk & AGP
+compileSdk=$(grep -E 'compileSdk(?:Version)?\s+[0-9]+' -h android/app/build.gradle* | grep -Eo '[0-9]+' | head -n1 || echo 33)
+agp=$(grep -R "com.android.tools.build:gradle" -n android | head -n1 | sed -E 's/.*gradle:([^"]+).*/\1/' || true)
+echo "Detected compileSdk=$compileSdk agp=$agp"
+
+# Ensure required SDK components exist
+bt="${compileSdk}.0.0"
+echo "Installing SDK bits: build-tools;$bt, platforms;android-$compileSdk"
+sdkmanager "build-tools;$bt" "platforms;android-$compileSdk" "platform-tools" >/dev/null || true
+
+# Quick dry-run to capture mismatches fast
+set +e
+(cd android && ./gradlew :app:assembleDebug -m -Dorg.gradle.jvmargs="-Xmx3g" ) &> build-dryrun.log
+rc=$?
+set -e
+if [[ $rc -ne 0 ]]; then
+  echo "Dry-run flagged issues (top lines):"
+  sed -n '1,200p' build-dryrun.log
+fi
+
+# If AGP demands a newer Gradle, auto-bump wrapper
+need=$(grep -Eo "requires Gradle [0-9]+\.[0-9]+(\.[0-9]+)?" build-dryrun.log | awk '{print $3}' | head -n1 || true)
+if [[ -n "$need" ]]; then
+  echo "AGP requires Gradle $need — bumping wrapper…"
+  file="android/gradle/wrapper/gradle-wrapper.properties"
+  sed -E -i.bak "s#distributionUrl=.*#distributionUrl=https\\://services.gradle.org/distributions/gradle-${need}-bin.zip#g" "$file"
+  echo "Wrapper bumped to Gradle $need"
+fi
+
+# One more attempt: resolve deps only, to surface conflicts
+set +e
+(cd android && ./gradlew :app:dependencies --configuration releaseRuntimeClasspath -Dorg.gradle.jvmargs="-Xmx3g" ) &> build-deps.log
+set -e
+echo "Dependency graph captured to build-deps.log"
+
+echo "Android Doctor complete."


### PR DESCRIPTION
Adds android-actions/setup-android, preflight doctor that auto-installs SDK & bumps Gradle wrapper if AGP demands it, stronger memory flags, and artifacted logs. Skips Play when creds look demo.