### PR TITLE
ci: add Android build back and attach APK to releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: CI-Simple
+﻿name: CI
 on:
   push:
     branches: ['**']
@@ -10,16 +10,80 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Test from $GITHUB_REF ($GITHUB_SHA)"
+
+  build_android:
+    name: Android Debug APK
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3g -Dkotlin.daemon.jvm.options=-Xmx2g
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: android-actions/setup-android@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+      - name: Compute version outputs
+        id: ver
+        run: |
+          ref="${GITHUB_REF_NAME}"
+          if [[ "$ref" =~ ^v[0-9] ]]; then name="${ref#v}"; else name="0.0.0"; fi
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "code=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+      - name: Accept Android licenses
+        run: yes | sdkmanager --licenses || true
+      - name: Install SDK bits
+        run: |
+          SDK=$(grep -E 'compileSdk(?:Version)?[[:space:]]+[0-9]+' -h android/app/build.gradle* | grep -Eo '[0-9]+' | head -n1 || echo 33)
+          BT="${SDK}.0.0"
+          sdkmanager "platforms;android-$SDK" "build-tools;$BT" "platform-tools" || true
+      - name: Flutter doctor
+        run: flutter doctor -v
+      - name: Pub get (resilient)
+        run: |
+          for i in 1 2 3; do flutter pub get && break || sleep $((i*5)); done
+      - name: Build APK
+        run: |
+          flutter build apk --debug \
+            --build-name "${{ steps.ver.outputs.name }}" \
+            --build-number "${{ steps.ver.outputs.code }}"
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Android Debug APK
+          path: build/app/outputs/flutter-apk/*.apk
+          retention-days: 30
       
   release:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test]
+    needs: [test, build_android]
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
-      - run: echo "Creating release for ${{ github.ref_name }}"
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: Android Debug APK
+          path: dist/android
+      - name: Prepare files
+        run: |
+          mkdir -p dist
+          cp dist/android/*.apk "dist/HoldThatThought-${GITHUB_REF_NAME}-debug.apk"
+      - name: Generate SHA256
+        run: |
+          cd dist
+          (sha256sum HoldThatThought-${GITHUB_REF_NAME}-debug.apk || shasum -a 256 HoldThatThought-${GITHUB_REF_NAME}-debug.apk) > HoldThatThought-${GITHUB_REF_NAME}-debug.apk.sha256
       - uses: softprops/action-gh-release@v2
         with:
+          files: |
+            dist/HoldThatThought-${{ github.ref_name }}-debug.apk
+            dist/HoldThatThought-${{ github.ref_name }}-debug.apk.sha256
+          append_body: true
           body: "Automated release for ${{ github.ref_name }}"


### PR DESCRIPTION
Adds Android Debug APK job and extends release job to attach APK + SHA256 for v* tag pushes. Keeps minimal/robust structure.