### PR TITLE
android: fix Gradle repo mode & repos; real APK build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,11 @@ jobs:
       - name: Pub get (resilient)
         run: |
           for i in 1 2 3; do flutter pub get && break || sleep $((i*5)); done
-      - name: Build APK (mock until Gradle fixed)
+      - name: Build APK
         run: |
-          mkdir -p build/app/outputs/flutter-apk/
-          echo "Mock APK for ${GITHUB_REF_NAME} - Gradle issue pending fix" > build/app/outputs/flutter-apk/app-debug.apk
+          flutter build apk --debug \
+            --build-name "${{ steps.ver.outputs.name }}" \
+            --build-number "${{ steps.ver.outputs.code }}"
       - name: Upload Android artifact
         uses: actions/upload-artifact@v4
         with:

--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -7,6 +7,8 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://jitpack.io")
+        maven(url = "https://storage.googleapis.com/download.flutter.io")
     }
 }
 

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -27,9 +27,11 @@ include(":app")
 
 
 dependencyResolutionManagement {
-    // repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositoriesMode.set(RepositoriesMode.PREFER_SETTINGS)
     repositories {
         google()
         mavenCentral()
+        maven(url = "https://jitpack.io")
+        maven(url = "https://storage.googleapis.com/download.flutter.io")
     }
 }


### PR DESCRIPTION
Switch repositoriesMode to PREFER_SETTINGS and add google/mavenCentral/jitpack/flutter repos. Restores real Flutter APK build instead of mock.