### PR TITLE
android/ci: fix Jetifier OOM (workers=1, heap tuned, cache)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,18 @@ jobs:
     name: Android Debug APK
     runs-on: ubuntu-latest
     env:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3g -Dkotlin.daemon.jvm.options=-Xmx2g
+      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx1536m
+      JAVA_TOOL_OPTIONS: -Xmx1g
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
           java-version: '17'
+      - uses: gradle/gradle-build-action@v3
+        with:
+          cache-read-only: false
+          gradle-home-cache-cleanup: true
       - uses: android-actions/setup-android@v3
       - uses: subosito/flutter-action@v2
         with:
@@ -41,6 +46,11 @@ jobs:
           SDK=$(grep -E 'compileSdk(?:Version)?[[:space:]]+[0-9]+' -h android/app/build.gradle* | grep -Eo '[0-9]+' | head -n1 || echo 33)
           BT="${SDK}.0.0"
           sdkmanager "platforms;android-$SDK" "build-tools;$BT" "platform-tools" || true
+      - name: Show gradle.properties
+        run: |
+          echo '--- android/gradle.properties ---'
+          cat android/gradle.properties || true
+          echo '----------------------------------'
       - name: Flutter doctor
         run: flutter doctor -v
       - name: Pub get (resilient)

--- a/android/gradle.properties
+++ b/android/gradle.properties
@@ -1,15 +1,10 @@
-# Android/Gradle properties for Flutter CI
-# AndroidX and Jetifier
 android.useAndroidX=true
 android.enableJetifier=true
-
-# Gradle optimization
-org.gradle.jvmargs=-Xmx4g -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxMetaspaceSize=512m -Dfile.encoding=UTF-8 -XX:+UseParallelGC
 org.gradle.daemon=true
 org.gradle.parallel=true
 org.gradle.caching=true
-
-# Android build optimization
 android.enableR8.fullMode=true
 android.nonTransitiveRClass=true
-
+kotlin.daemon.jvm.options=-Xmx1536m
+org.gradle.workers.max=1


### PR DESCRIPTION
Prevents Jetifier OutOfMemory by capping Gradle workers to 1 and tuning heaps; adds Gradle cache and logs gradle.properties for traceability.