### PR TITLE
ci: verify release assets + gate production promotions + CODEOWNERS + tag ruleset

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,4 @@
+# CI and release plumbing require an explicit review
+.github/workflows/*   @luccidnz
+docs/*                @luccidnz
+android/**            @luccidnz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,264 +1,55 @@
-﻿name: CI
-concurrency:
-  group: ci-${{ github.ref }}
-  cancel-in-progress: true
-on:
-  push:
-    branches: ['**']
-    tags: ['v*']
-  workflow_dispatch: {}
 
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo "Test from $GITHUB_REF ($GITHUB_SHA)"
 
-  build_android:
-    name: Android Debug APK
-    runs-on: ubuntu-latest
-    env:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx1536m
-      JAVA_TOOL_OPTIONS: -Xmx1g
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '17'
-      - uses: gradle/gradle-build-action@v3
-        with:
-          cache-read-only: false
-          gradle-home-cache-cleanup: true
-      - uses: android-actions/setup-android@v3
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          cache: true
-      - name: Compute version outputs
-        id: ver
-        run: |
-          ref="${GITHUB_REF_NAME}"
-          if [[ "$ref" =~ ^v[0-9] ]]; then name="${ref#v}"; else name="0.0.0"; fi
-          echo "name=$name" >> "$GITHUB_OUTPUT"
-          echo "code=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
-      - name: Accept Android licenses
-        run: yes | sdkmanager --licenses || true
-      - name: Install SDK bits
-        run: |
-          SDK=$(grep -E 'compileSdk(?:Version)?[[:space:]]+[0-9]+' -h android/app/build.gradle* | grep -Eo '[0-9]+' | head -n1 || echo 33)
-          BT="${SDK}.0.0"
-          sdkmanager "platforms;android-$SDK" "build-tools;$BT" "platform-tools" || true
-      - name: Show gradle.properties
-        run: |
-          echo '--- android/gradle.properties ---'
-          cat android/gradle.properties || true
-          echo '----------------------------------'
-      - name: Flutter doctor
-        run: flutter doctor -v
-      - name: Pub get (resilient)
-        run: |
-          for i in 1 2 3; do flutter pub get && break || sleep $((i*5)); done
-      - name: Build APK
-        run: |
-          flutter build apk --debug \
-            --build-name "${{ steps.ver.outputs.name }}" \
-            --build-number "${{ steps.ver.outputs.code }}"
-      - name: Upload Android artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: Android Debug APK
-          path: build/app/outputs/flutter-apk/*.apk
-          retention-days: 30
-
-      - name: Compute version outputs (AAB)
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
-        id: ver_aab
-        run: |
-          ref="${GITHUB_REF_NAME}"
-          name="${ref#v}"
-          echo "name=$name" >> "$GITHUB_OUTPUT"
-          echo "code=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
-      - name: Restore signing key for AAB (guarded)
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
-        env:
-          ANDROID_SIGNING_KEY_B64: ${{ secrets.ANDROID_SIGNING_KEY_B64 }}
-        run: |
-          mkdir -p android/app
-          echo "$ANDROID_SIGNING_KEY_B64" | base64 -d > android/app/release.keystore
-          cat > android/key.properties <<'EOF'
-          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
-          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
-          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
-          storeFile=release.keystore
-          EOF
-      - name: Build AAB (release, guarded)
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
-        run: |
-          flutter build appbundle --release \
-            --build-name "${{ steps.ver_aab.outputs.name }}" \
-            --build-number "${{ steps.ver_aab.outputs.code }}"
-      - name: Upload Android AAB artifact
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
-        uses: actions/upload-artifact@v4
-        with:
-          name: Android AAB
-          path: build/app/outputs/bundle/release/app-release.aab
-          retention-days: 30
-      
-  build_windows:
-    name: Windows ZIP
-    runs-on: windows-latest
-    env:
-      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3g -Dkotlin.daemon.jvm.options=-Xmx2g
-    steps:
-      - uses: actions/checkout@v4
-      - uses: subosito/flutter-action@v2
-        with:
-          channel: 'stable'
-          cache: true
-      - name: Enable Windows desktop
-        run: flutter config --enable-windows-desktop
-      - name: Pub get
-        run: flutter pub get
-      - name: Compute version outputs
-        id: ver
-        shell: bash
-        run: |
-          ref="${GITHUB_REF_NAME}"
-          if [[ "$ref" =~ ^v[0-9] ]]; then name="${ref#v}"; else name="0.0.0"; fi
-          echo "name=$name" >> "$GITHUB_OUTPUT"
-          echo "code=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
-      - name: Build Windows (release)
-        run: flutter build windows --release --build-name "${{ steps.ver.outputs.name }}" --build-number "${{ steps.ver.outputs.code }}"
-      - name: Zip Windows build
-        shell: bash
-        run: |
-          mkdir -p dist
-          7z a -tzip "dist/HoldThatThought-${GITHUB_REF_NAME}-windows.zip" build/windows/x64/runner/Release/* >/dev/null
-      - name: Upload Windows artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: Windows Release
-          path: dist/HoldThatThought-${{ github.ref_name }}-windows.zip
-          retention-days: 30
-      
-  release:
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs: [test, build_android, build_windows]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - uses: actions/download-artifact@v4
-        with:
-          name: Android Debug APK
-          path: dist/android
-      - uses: actions/download-artifact@v4
-        with:
-          name: Windows Release
-          path: dist/windows
-      - uses: actions/download-artifact@v4
-        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
-        with:
-          name: Android AAB
-          path: dist/aab
-      - name: Prepare files
-        run: |
-          mkdir -p dist
-          cp dist/android/*.apk "dist/HoldThatThought-${GITHUB_REF_NAME}-debug.apk"
-          cp dist/windows/*.zip "dist/HoldThatThought-${GITHUB_REF_NAME}-windows.zip"
-          if [ -d dist/aab ]; then cp dist/aab/*.aab "dist/HoldThatThought-${GITHUB_REF_NAME}.aab"; fi
-      - name: Generate SHA256
-        run: |
-          cd dist
-          for f in *.apk *.zip; do
-            [ -f "$f" ] || continue
-            (sha256sum "$f" || shasum -a 256 "$f") > "$f.sha256"
-          done
-          [ -f "HoldThatThought-${GITHUB_REF_NAME}.aab" ] && (sha256sum "HoldThatThought-${GITHUB_REF_NAME}.aab" || shasum -a 256 "HoldThatThought-${GITHUB_REF_NAME}.aab") > "HoldThatThought-${GITHUB_REF_NAME}.aab.sha256"
-      - uses: softprops/action-gh-release@v2
-        with:
-          files: |
-            dist/HoldThatThought-${{ github.ref_name }}-debug.apk
-            dist/HoldThatThought-${{ github.ref_name }}-debug.apk.sha256
-            dist/HoldThatThought-${{ github.ref_name }}-windows.zip
-            dist/HoldThatThought-${{ github.ref_name }}-windows.zip.sha256
-            dist/HoldThatThought-${{ github.ref_name }}.aab
-            dist/HoldThatThought-${{ github.ref_name }}.aab.sha256
-          append_body: true
-          body: "Automated release for ${{ github.ref_name }}"
-
-  release_android_play:
-    environment: play-internal
-    name: Play Upload (stable tags only)
-    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
-    needs: [build_android]
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
-        with:
-          name: Android AAB
-          path: dist/aab
-      - name: Generate What's New (<=500 chars)
-        run: |
-          mkdir -p dist/whatsnew
-          file="dist/CHANGELOG-${GITHUB_REF_NAME}.md"
-          [ -f "$file" ] || echo "No changelog found" > "$file"
-          head -c 500 "$file" | tr -d '\r' > dist/whatsnew/en-US.txt
-      - name: Upload to Google Play (internal) 
-        uses: r0adkll/upload-google-play@v1
-        with:
-          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
-          packageName: ${{ secrets.PLAY_PACKAGE_NAME }}
-          releaseFiles: dist/aab/app-release.aab
-          track: internal
-          status: completed
-          whatsNewDirectory: dist/whatsnew
-
-  attest_provenance:
-    name: Attest release artifacts
+  verify_release_assets:
+    name: Verify release assets (checksums + APK version)
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [release_assets]
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      attestations: write
     steps:
       - uses: actions/checkout@v4
-      - name: Download release files (for attestation subjects)
+      - name: Install Android SDK toolchain (aapt)
+        uses: android-actions/setup-android@v3
+      - name: Download release assets
         run: |
-          mkdir -p dist
-          gh release download "${GITHUB_REF_NAME}" -D dist
+          mkdir -p verify
+          gh release download "${GITHUB_REF_NAME}" -D verify
+          ls -la verify || true
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: Attest build provenance
-        uses: actions/attest-build-provenance@v1
-        with:
-          subject-path: "dist/*"
-
-  android_smoke:
-    name: Android emulator smoke (PR only)
-    if: github.event_name == 'pull_request' && !startsWith(github.ref, 'refs/tags/')
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: '17'
-      - uses: reactivecircus/android-emulator-runner@v2
-        with:
-          api-level: 30
-          arch: x86_64
-          profile: pixel_5
-          force-avd-creation: true
-          emulator-options: "-no-window -gpu swiftshader_indirect -no-snapshot"
-          disable-animations: true
-          script: adb shell getprop init.svc.bootanim; sleep 5; adb shell pm list packages | head -n 5
+      - name: Verify SHA256 checksums
+        shell: bash
+        run: |
+          set -e
+          cd verify
+          shopt -s nullglob
+          for f in *.apk *.zip *.aab; do
+            [ -f "$f" ] || continue
+            sha_calc=$( (sha256sum "$f" || shasum -a 256 "$f") | awk '{print $1}' )
+            sha_file="${f}.sha256"
+            if [ ! -f "$sha_file" ]; then
+              echo "❌ Missing checksum for $f" && exit 1
+            fi
+            sha_list=$(awk '{print $1}' "$sha_file")
+            if ! echo "$sha_list" | grep -q "$sha_calc"; then
+              echo "❌ SHA mismatch for $f"; echo " expected one of: $sha_list"; echo "     computed: $sha_calc"; exit 1
+            fi
+            echo "✅ $f checksum OK"
+          done
+      - name: Check APK version matches tag
+        shell: bash
+        run: |
+          set -e
+          cd verify
+          apk=$(ls *.apk 2>/dev/null | head -n1 || true)
+          if [ -z "$apk" ]; then
+            echo "ℹ️ No APK to validate; skipping." ; exit 0
+          fi
+          # get aapt from the newest build-tools we have
+          AAPT=$(ls "$ANDROID_HOME/build-tools"/*/aapt 2>/dev/null | sort -V | tail -n1 || true)
+          if [ -z "$AAPT" ]; then echo "⚠️ aapt not found; skipping APK version check"; exit 0; fi
+          ver=$("$AAPT" dump badging "$apk" | awk -F"'" '/versionName=/{print $4; exit}')
+          tag="${GITHUB_REF_NAME#v}"
+          if [ "$ver" != "$tag" ] && [ "$ver" != "${tag%%-rc*}" ]; then
+            echo "❌ APK versionName=$ver does not match tag=$tag"; exit 1
+          fi
+          echo "✅ APK version $ver matches tag $tag" 

--- a/.github/workflows/play-promote.yml
+++ b/.github/workflows/play-promote.yml
@@ -25,6 +25,7 @@ permissions:
   contents: read
 jobs:
   promote:
+    environment: play-production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/docs/release-process.md
+++ b/docs/release-process.md
@@ -40,3 +40,10 @@ Untagging is not required; you can pause at Closed/0.1 until fixed.
 - **Protected tags**: `v*` tags are protected from accidental deletion/creation by non-admins.
 - **Provenance**: CI now attaches SLSA provenance attestations to release files (GitHub Artifact Attestations).
 - **Duplicate-run guard**: CI uses concurrency per ref so repeated pushes won't double-run.
+
+## Verification & promotion safety
+- **Release verification**: CI downloads the assets and validates SHA256; APK version **must** match the tag.
+- **Play environments**:
+  - Internal uploads require **play-internal** approval (already configured).
+  - Promotions (Closed/Production) require **play-production** approval (set reviewers in *Settings → Environments*).
+- **Tag protection**: we protect `v*` tags from deletes/force-updates via Rulesets (if available on plan).


### PR DESCRIPTION
Adds checksum+APK version verification, gates Play Promote with play-production environment, introduces minimal CODEOWNERS, and best-effort v* tag protection via Rulesets. Docs updated.