### PR TITLE
ci(windows): code signing on stable tags + verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,230 @@
+name: CI
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
 
+on:
+  push:
+    branches: ['**']
+    tags: ['v*']
+  workflow_dispatch: {}
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Test from $GITHUB_REF ($GITHUB_SHA)"
+      
+  build_android:
+    name: Android Debug APK
+    runs-on: ubuntu-latest
+    env:
+      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx4g -Dkotlin.daemon.jvm.options=-Xmx1536m
+      JAVA_TOOL_OPTIONS: -Xmx1g
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: gradle/gradle-build-action@v3
+        with:
+          cache-read-only: false
+          gradle-home-cache-cleanup: true
+      - uses: android-actions/setup-android@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+      - name: Compute version outputs
+        id: ver
+        run: |
+          ref="${GITHUB_REF_NAME}"
+          if [[ "$ref" =~ ^v[0-9] ]]; then name="${ref#v}"; else name="0.0.0"; fi
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "code=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+      - name: Accept Android licenses
+        run: yes | sdkmanager --licenses || true
+      - name: Install SDK bits
+        run: |
+          SDK=$(grep -E 'compileSdk(?:Version)?[[:space:]]+[0-9]+' -h android/app/build.gradle* | grep -Eo '[0-9]+' | head -n1 || echo 33)
+          BT="${SDK}.0.0"
+          sdkmanager "platforms;android-$SDK" "build-tools;$BT" "platform-tools" || true
+      - name: Show gradle.properties
+        run: |
+          echo '--- android/gradle.properties ---'
+          cat android/gradle.properties || true
+          echo '-----------------------------------'
+      - name: Flutter doctor
+        run: flutter doctor -v
+      - name: Pub get (resilient)
+        run: |
+          for i in 1 2 3; do flutter pub get && break || sleep $((i*5)); done
+      - name: Build APK
+        run: |
+          flutter build apk --debug \
+            --build-name "${{ steps.ver.outputs.name }}" \
+            --build-number "${{ steps.ver.outputs.code }}"
+      - name: Upload Android artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Android Debug APK
+          path: build/app/outputs/flutter-apk/*.apk
+          retention-days: 30
+
+      - name: Compute version outputs (AAB)
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
+        id: ver_aab
+        run: |
+          ref="${GITHUB_REF_NAME}"
+          name="${ref#v}"
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "code=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+      - name: Restore signing key for AAB (guarded)
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
+        env:
+          ANDROID_SIGNING_KEY_B64: ${{ secrets.ANDROID_SIGNING_KEY_B64 }}
+        run: |
+          mkdir -p android/app
+          echo "$ANDROID_SIGNING_KEY_B64" | base64 -d > android/app/release.keystore
+          cat > android/key.properties <<'EOF'
+          storePassword=${{ secrets.ANDROID_KEYSTORE_PASSWORD }}
+          keyPassword=${{ secrets.ANDROID_KEY_PASSWORD }}
+          keyAlias=${{ secrets.ANDROID_KEY_ALIAS }}
+          storeFile=release.keystore
+          EOF
+      - name: Build AAB (release, guarded)
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
+        run: |
+          flutter build appbundle --release \
+            --build-name "${{ steps.ver_aab.outputs.name }}" \
+            --build-number "${{ steps.ver_aab.outputs.code }}"
+      - name: Upload Android AAB artifact
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
+        uses: actions/upload-artifact@v4
+        with:
+          name: Android AAB
+          path: build/app/outputs/bundle/release/app-release.aab
+          retention-days: 30
+
+  build_windows:
+    name: Windows ZIP
+    runs-on: windows-latest
+    env:
+      GRADLE_OPTS: -Dorg.gradle.jvmargs=-Xmx3g -Dkotlin.daemon.jvm.options=-Xmx2g
+    steps:
+      - uses: actions/checkout@v4
+      - uses: subosito/flutter-action@v2
+        with:
+          channel: 'stable'
+          cache: true
+      - name: Enable Windows desktop
+        run: flutter config --enable-windows-desktop
+      - name: Pub get
+        run: flutter pub get
+      - name: Compute version outputs
+        id: ver
+        shell: bash
+        run: |
+          ref="${GITHUB_REF_NAME}"
+          if [[ "$ref" =~ ^v[0-9] ]]; then name="${ref#v}"; else name="0.0.0"; fi
+          echo "name=$name" >> "$GITHUB_OUTPUT"
+          echo "code=${GITHUB_RUN_NUMBER}" >> "$GITHUB_OUTPUT"
+      - name: Build Windows (release)
+        run: |
+          flutter build windows --release \
+            --build-name "${{ steps.ver.outputs.name }}" \
+            --build-number "${{ steps.ver.outputs.code }}"
+      - name: Restore code signing cert (guarded)
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc') && secrets.WIN_CERT_PFX_B64 != ''
+        shell: pwsh
+        env:
+          WIN_CERT_PFX_B64: ${{ secrets.WIN_CERT_PFX_B64 }}
+          WIN_CERT_PASSWORD: ${{ secrets.WIN_CERT_PASSWORD }}
+        run: |
+          New-Item -ItemType Directory -Path dist -Force | Out-Null
+          $pfxPath = "dist/code-signing.pfx"
+          [IO.File]::WriteAllBytes($pfxPath, [Convert]::FromBase64String($env:WIN_CERT_PFX_B64))
+          $Secure = ConvertTo-SecureString -String $env:WIN_CERT_PASSWORD -AsPlainText -Force
+          # Import into CurrentUser\My to support signtool
+          Import-PfxCertificate -FilePath $pfxPath -CertStoreLocation Cert:\CurrentUser\My -Password $Secure | Out-Null
+      - name: Sign EXE files (guarded)
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc') && secrets.WIN_CERT_PFX_B64 != ''
+        shell: pwsh
+        run: |
+          $runnerDir = "build/windows/x64/runner/Release"
+          if (-not (Test-Path $runnerDir)) { throw "Runner output not found: $runnerDir" }
+          $ts='http://timestamp.digicert.com'
+          $exes = Get-ChildItem $runnerDir -Filter *.exe -Recurse
+          if ($exes.Count -eq 0) { throw "No EXEs found to sign." }
+          foreach ($f in $exes) {
+            & 'C:\Program Files (x86)\Windows Kits\10\bin\x64\signtool.exe' sign /fd SHA256 /tr $ts /td SHA256 "$($f.FullName)"
+          }
+          # Verify signatures immediately
+          foreach ($f in $exes) {
+            $sig = Get-AuthenticodeSignature $f.FullName
+            if ($sig.Status -ne 'Valid') { throw "Signature invalid on $($f.Name): $($sig.Status)" }
+          }
+      - name: Zip Windows build
+        shell: bash
+        run: |
+          mkdir -p dist
+          7z a -tzip "dist/HoldThatThought-${GITHUB_REF_NAME}-windows.zip" build/windows/x64/runner/Release/* >/dev/null
+      - name: Upload Windows artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: Windows Release
+          path: dist/HoldThatThought-${{ github.ref_name }}-windows.zip
+          retention-days: 30
+
+  release_assets:
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [test, build_android, build_windows]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/download-artifact@v4
+        with:
+          name: Android Debug APK
+          path: dist/android
+      - uses: actions/download-artifact@v4
+        with:
+          name: Windows Release
+          path: dist/windows
+      - uses: actions/download-artifact@v4
+        if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
+        with:
+          name: Android AAB
+          path: dist/aab
+      - name: Prepare files
+        run: |
+          mkdir -p dist
+          cp dist/android/*.apk "dist/HoldThatThought-${GITHUB_REF_NAME}-debug.apk"
+          cp dist/windows/*.zip "dist/HoldThatThought-${GITHUB_REF_NAME}-windows.zip"
+          if [ -d dist/aab ]; then cp dist/aab/*.aab "dist/HoldThatThought-${GITHUB_REF_NAME}.aab"; fi
+      - name: Generate SHA256
+        run: |
+          cd dist
+          for f in *.apk *.zip; do
+            [ -f "$f" ] || continue
+            (sha256sum "$f" || shasum -a 256 "$f") > "$f.sha256"
+          done
+          [ -f "HoldThatThought-${GITHUB_REF_NAME}.aab" ] && (sha256sum "HoldThatThought-${GITHUB_REF_NAME}.aab" || shasum -a 256 "HoldThatThought-${GITHUB_REF_NAME}.aab") > "HoldThatThought-${GITHUB_REF_NAME}.aab.sha256"
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/HoldThatThought-${{ github.ref_name }}-debug.apk
+            dist/HoldThatThought-${{ github.ref_name }}-debug.apk.sha256
+            dist/HoldThatThought-${{ github.ref_name }}-windows.zip
+            dist/HoldThatThought-${{ github.ref_name }}-windows.zip.sha256
+            dist/HoldThatThought-${{ github.ref_name }}.aab
+            dist/HoldThatThought-${{ github.ref_name }}.aab.sha256
+          append_body: true
+          body: "Automated release for ${{ github.ref_name }}"
 
   verify_release_assets:
     name: Verify release assets (checksums + APK version)
@@ -52,4 +278,102 @@
           if [ "$ver" != "$tag" ] && [ "$ver" != "${tag%%-rc*}" ]; then
             echo "❌ APK versionName=$ver does not match tag=$tag"; exit 1
           fi
-          echo "✅ APK version $ver matches tag $tag" 
+          echo "✅ APK version $ver matches tag $tag"
+
+  verify_windows_sign:
+    name: Verify Windows signatures (stable tags)
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc') && secrets.WIN_CERT_PFX_B64 != ''
+    needs: [release_assets]
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download Windows ZIP
+        run: |
+          mkdir verify
+          gh release download "${{ github.ref_name }}" -p "*windows.zip" -D verify
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Expand ZIP and verify signatures
+        shell: pwsh
+        run: |
+          $zip = Get-ChildItem verify -Filter *.zip | Select-Object -First 1
+          if (-not $zip) { throw "Windows ZIP not found" }
+          Expand-Archive -Path $zip.FullName -DestinationPath verify/unzipped -Force
+          $exes = Get-ChildItem verify/unzipped -Recurse -Filter *.exe
+          if ($exes.Count -eq 0) { throw "No EXEs found in ZIP to verify" }
+          foreach ($f in $exes) {
+            $sig = Get-AuthenticodeSignature $f.FullName
+            if ($sig.Status -ne 'Valid') { throw "Unsigned or invalid signature on $($f.FullName): $($sig.Status)" }
+          }
+          Write-Host "✅ All EXEs are properly signed."
+
+  release_android_play:
+    environment: play-internal
+    name: Play Upload (stable tags only)
+    if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref_name, '-rc')
+    needs: [build_android]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
+        with:
+          name: Android AAB
+          path: dist/aab
+      - name: Generate What's New (<=500 chars)
+        run: |
+          mkdir -p dist/whatsnew
+          file="dist/CHANGELOG-${GITHUB_REF_NAME}.md"
+          [ -f "$file" ] || echo "No changelog found" > "$file"
+          head -c 500 "$file" | tr -d '\r' > dist/whatsnew/en-US.txt
+      - name: Upload to Google Play (internal)
+        uses: r0adkll/upload-google-play@v1
+        with:
+          serviceAccountJsonPlainText: ${{ secrets.GOOGLE_PLAY_SERVICE_ACCOUNT_JSON }}
+          packageName: ${{ secrets.PLAY_PACKAGE_NAME }}
+          releaseFiles: dist/aab/app-release.aab
+          track: internal
+          status: completed
+          whatsNewDirectory: dist/whatsnew
+
+  attest_provenance:
+    name: Attest release artifacts
+    if: startsWith(github.ref, 'refs/tags/v')
+    needs: [release_assets]
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      attestations: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Download release files (for attestation subjects)
+        run: |
+          mkdir -p dist
+          gh release download "${GITHUB_REF_NAME}" -D dist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v1
+        with:
+          subject-path: "dist/*"
+
+  android_smoke:
+    name: Android emulator smoke (PR only)
+    if: github.event_name == 'pull_request' && !startsWith(github.ref, 'refs/tags/')
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '17'
+      - uses: reactivecircus/android-emulator-runner@v2
+        with:
+          api-level: 30
+          arch: x86_64
+          profile: pixel_5
+          force-avd-creation: true
+          emulator-options: "-no-window -gpu swiftshader_indirect -no-snapshot"
+          disable-animations: true
+          script: adb shell getprop init.svc.bootanim; sleep 5; adb shell pm list packages | head -n 5

--- a/docs/windows-signing.md
+++ b/docs/windows-signing.md
@@ -1,0 +1,29 @@
+# Windows Code Signing (CI)
+
+## Secrets (Repository → Settings → Secrets and variables → Actions)
+- `WIN_CERT_PFX_B64` — Base64 of your code signing certificate `.pfx`
+  - macOS: `base64 -i cert.pfx | pbcopy`
+  - Linux: `base64 -w 0 cert.pfx > out.b64`
+  - Windows (PowerShell): `[Convert]::ToBase64String([IO.File]::ReadAllBytes('cert.pfx'))`
+- `WIN_CERT_PASSWORD` — password for the PFX
+
+## Behavior
+- On **stable tags** (`vX.Y.Z`) only, if `WIN_CERT_PFX_B64` is set:
+  1) CI restores the certificate to the user store.
+  2) Signs all EXEs under `build/windows/x64/runner/Release/` with SHA256 and a DigiCert timestamp.
+  3) Packages the **signed** binaries into the ZIP.
+  4) A separate Windows job downloads the release ZIP and validates that all EXEs are **Valid** signed.
+
+- RC tags (`vX.Y.Z-rcN`) skip signing entirely.
+
+## Local validation
+On Windows PowerShell:
+```pwsh
+Get-AuthenticodeSignature 'path\to\your.exe'
+```
+
+## Troubleshooting
+- If `signtool.exe` is not found, ensure Windows SDK is installed
+- Certificate must be valid for code signing
+- Timestamp server must be reachable (uses DigiCert)
+- Only EXE files in `build/windows/x64/runner/Release/` are signed


### PR DESCRIPTION
Signs Windows EXEs on stable tags when WIN_CERT_PFX_B64/Password exist; adds Windows job to verify signatures from release ZIP; docs included.